### PR TITLE
orderBy里支持原生的语法

### DIFF
--- a/src/Mysqli.php
+++ b/src/Mysqli.php
@@ -1401,6 +1401,8 @@ class Mysqli
         foreach ($this->orderBy as $prop => $value) {
             if (strtolower(str_replace(" ", "", $prop)) == 'rand()') {
                 $this->query .= "rand(), ";
+            }elseif(strstr($prop,"RAW(")){
+	            $this->query .= str_replace("RAW(", "(", $prop);
             } else {
                 $this->query .= $prop . " " . $value . ", ";
             }

--- a/src/TpORM.php
+++ b/src/TpORM.php
@@ -207,7 +207,7 @@ class TpORM extends DbObject
 				foreach( $whereProps as $field => $value ){
 					// 用于支持原生语句
 					if(is_int($field)){
-						$this->getDb()->where( $field);
+						$this->getDb()->where( $value);
 					}else if( is_array( $value ) && key( $value ) === 0 ){
 						// 用于支持['in',[123,232,32,3,4]]格式
 						$this->getDb()->where( $field, [$value[0] => $value[1]] );

--- a/src/TpORM.php
+++ b/src/TpORM.php
@@ -205,7 +205,10 @@ class TpORM extends DbObject
 		if( !empty( $whereProps ) ){
 			if( is_array( $whereProps ) ){
 				foreach( $whereProps as $field => $value ){
-					if( is_array( $value ) && key( $value ) === 0 ){
+					// 用于支持原生语句
+					if(is_int($field)){
+						$this->getDb()->where( $field);
+					}else if( is_array( $value ) && key( $value ) === 0 ){
 						// 用于支持['in',[123,232,32,3,4]]格式
 						$this->getDb()->where( $field, [$value[0] => $value[1]] );
 					} else{

--- a/src/TpORM.php
+++ b/src/TpORM.php
@@ -140,7 +140,7 @@ class TpORM extends DbObject
 	{
 		$page = $pageInfo[0] - 1;
 		$rows = $pageInfo[1];
-		$this->limit( [$page, $rows] );
+		$this->limit( [$page*$rows, $rows] );
 		return $this;
 	}
 


### PR DESCRIPTION
这个请慎重考虑下，以免有bug，很常用，复杂的搜索我想用一些原生函数就不行了，目前该库就支持一个rand()不够用的，如果写rawQuery呢  那可就太多了  where join 啥的很多，所以希望能提供一种方法在orderBy里追加原生语句