### PR TITLE
更新了 raw 方法，添加了 getColumn 和 getScalar 方法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-.idea
+.idea/
+.vscode/
+vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mysqli
-本Mysqli构造器基于 https://github.com/ThingEngineer/PHP-MySQLi-Database-Class 移植实现的协成安全版本。
+本Mysqli构造器基于 https://github.com/ThingEngineer/PHP-MySQLi-Database-Class 移植实现的协程安全版本。
 ## 单元测试
 ```php
 ./vendor/bin/co-phpunit tests

--- a/phpunit.php
+++ b/phpunit.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * -- 新建测试用的库
+ * CREATE DATABASE IF NOT EXISTS demo
+ * DEFAULT CHARACTER SET utf8mb4
+ * DEFAULT COLLATE utf8mb4_general_ci;
+ *
+ * -- 新建测试用的表
+ * CREATE TABLE demo.user_test_list (
+ *     name varchar(64) NULL,
+ *     age TINYINT UNSIGNED NULL,
+ *     addTime DATETIME NULL,
+ *     state TINYINT UNSIGNED NULL
+ * )
+ * ENGINE=InnoDB
+ * DEFAULT CHARSET=utf8mb4
+ * COLLATE=utf8mb4_general_ci;
+ */
+
 defined("MYSQL_CONFIG") ?: define('MYSQL_CONFIG', [
     'host'          => '127.0.0.1',
     'port'          => 3306,

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -763,9 +763,11 @@ class QueryBuilder
         $this->raw("rollback");
     }
 
-    public function raw($sql)
+    public function raw($sql): QueryBuilder
     {
         $this->lastQuery = $this->lastPrepareQuery = $sql;
+
+        return $this;
     }
 
     /*

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -464,6 +464,35 @@ class QueryBuilder
     }
 
     /**
+     * SELECT 获取某一列的数据
+     * @param $tableName
+     * @param string $columns
+     * @param array|int|null $numRows
+     * @return QueryBuilder|null
+     */
+    public function getColumn($tableName, $columns = null, $numRows = null): ?QueryBuilder
+    {
+        if (!is_string($columns)) {
+            $columns = $this->_field;
+            if (is_array($columns) && count($columns) > 0) {
+                $columns = explode(',', str_replace(' ', '', reset($columns)))[0];
+            }
+        }
+        return $this->get($tableName, $numRows, $columns);
+    }
+
+    /**
+     * SELECT 获取某一列第一行的数据
+     * @param $tableName
+     * @param string $columns
+     * @return QueryBuilder|null
+     */
+    public function getScalar($tableName, $columns = null): ?QueryBuilder
+    {
+        return $this->getColumn($tableName, $columns, 1);
+    }
+
+    /**
      * 插入数据
      * @param $tableName
      * @param $insertData
@@ -498,7 +527,7 @@ class QueryBuilder
             }
         }
 
-        $this->_buildInsert($tableName, $insertData, $option['replace'] ? 'REPLACE' : 'INSERT');
+        $this->_buildInsert($tableName, $insertData, isset($option['replace']) ? 'REPLACE' : 'INSERT');
         $this->reset();
         return $this;
     }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -55,6 +55,75 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals([],$this->builder->getLastBindParams());
     }
 
+    function testGetOne()
+    {
+        $this->builder->getOne('get');
+        $this->assertEquals('SELECT  * FROM get LIMIT 1',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  * FROM get LIMIT 1',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+    }
+
+    function testGetColumn()
+    {
+        $this->builder->getColumn('get');
+        $this->assertEquals('SELECT  * FROM get',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  * FROM get',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+
+        $this->builder->fields('testcolumn')->getColumn('get');
+        $this->assertEquals('SELECT  testcolumn FROM get',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  testcolumn FROM get',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+
+        $this->builder->fields('testcolumn1, testcolumn2')->getColumn('get');
+        $this->assertEquals('SELECT  testcolumn1 FROM get',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  testcolumn1 FROM get',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+
+        $this->builder->fields(['testcolumn1', 'testcolumn2'])->getColumn('get');
+        $this->assertEquals('SELECT  testcolumn1 FROM get',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  testcolumn1 FROM get',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+
+        $this->builder->getColumn('get', 'testcolumn');
+        $this->assertEquals('SELECT  testcolumn FROM get',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  testcolumn FROM get',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+
+        $this->builder->getColumn('get', 'testcolumn', 1);
+        $this->assertEquals('SELECT  testcolumn FROM get LIMIT 1',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  testcolumn FROM get LIMIT 1',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+
+        $this->builder->getColumn('get', 'testcolumn', [0, 10]);
+        $this->assertEquals('SELECT  testcolumn FROM get LIMIT 0, 10',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  testcolumn FROM get LIMIT 0, 10',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+    }
+
+    function testGetScalar()
+    {
+        $this->builder->getScalar('get', 'testscalar');
+        $this->assertEquals('SELECT  testscalar FROM get LIMIT 1',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  testscalar FROM get LIMIT 1',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+
+        $this->builder->fields('testscalar')->getScalar('get');
+        $this->assertEquals('SELECT  testscalar FROM get LIMIT 1',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  testscalar FROM get LIMIT 1',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+
+        $this->builder->fields('testcolumn1, testcolumn2')->getScalar('get');
+        $this->assertEquals('SELECT  testcolumn1 FROM get LIMIT 1',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  testcolumn1 FROM get LIMIT 1',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+
+        $this->builder->fields(['testcolumn1', 'testcolumn2'])->getScalar('get');
+        $this->assertEquals('SELECT  testcolumn1 FROM get LIMIT 1',$this->builder->getLastPrepareQuery());
+        $this->assertEquals('SELECT  testcolumn1 FROM get LIMIT 1',$this->builder->getLastQuery());
+        $this->assertEquals([],$this->builder->getLastBindParams());
+    }
+
     function testWhereGet()
     {
         $this->builder->where('col1',2)->get('whereGet');


### PR DESCRIPTION
1. 让 raw 方法也返回一个 QueryBuilder 对象让 raw 方法也返回一个 QueryBuilder 对象
主要是为了方便像这样的链式调用
$count = DbManager::getInstance()->getConnection()->query((new QueryBuilder()->raw('SELECT COUNT(1) AS n FROM table')))->getResult();

2. 添加了 getColumn 和 getScalar 方法
只是对 get 方法的进一步封装

3. 添加了相应的测试用例