### PR TITLE
where null值查询问题

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -1297,7 +1297,11 @@ class QueryBuilder
                     if (is_array($val)) {
                         $this->_bindParams($val);
                     } elseif ($val === null) {
-                        $this->_query .= ' ' . $operator . " NULL";
+                        if ($operator == '=') {
+                            $this->_query .= ' IS NULL';
+                        } else {
+                            $this->_query .= ' IS NOT NULL';
+                        }
                     } elseif ($val != 'DBNULL' || $val == '0') {
                         $this->_query .= $this->_buildPair($operator, $val);
                     }


### PR DESCRIPTION
where('time', null)

null 值查询问题,  避免null值构建条件语句成 `time = null`