### PR TITLE
where null 值查询不传操作符查询问题

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -1297,7 +1297,11 @@ class QueryBuilder
                     if (is_array($val)) {
                         $this->_bindParams($val);
                     } elseif ($val === null) {
-                        $this->_query .= ' ' . $operator . " NULL";
+                        if ($operator == '=') {
+                            $this->_query .= ' IS NULL';
+                        } else {
+                            $this->_query .= ' IS NOT NULL';
+                        }
                     } elseif ($val != 'DBNULL' || $val == '0') {
                         $this->_query .= $this->_buildPair($operator, $val);
                     }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -1297,10 +1297,18 @@ class QueryBuilder
                     if (is_array($val)) {
                         $this->_bindParams($val);
                     } elseif ($val === null) {
-                        if ($operator == '=') {
-                            $this->_query .= ' IS NULL';
-                        } else {
-                            $this->_query .= ' IS NOT NULL';
+                        switch($operator) {
+                            case '=':
+                                $this->_query .= ' IS NULL';
+                                break;
+                            case '!=':
+                                $this->_query .= ' IS NOT NULL';
+                                break;
+                            case '<>':
+                                $this->_query .= ' IS NOT NULL';
+                                break;
+                            default:
+                                $this->_query .= ' '.$operator.' NULL';
                         }
                     } elseif ($val != 'DBNULL' || $val == '0') {
                         $this->_query .= $this->_buildPair($operator, $val);


### PR DESCRIPTION
已改正
where('time', null) // time is null
where('time', null, '=') // time is null
where('time', null, 'is') // time is null
